### PR TITLE
fixed #18 (security vulnerability with jekyll  <= 3.7.3)

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM jekyll/builder
 
-LABEL version="0.3.0"
+LABEL version="0.3.1"
 LABEL description="develop and generate documentation sites with AsciiDoctor"
 LABEL vendor="arc42 and docToolChain"
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.11)
+    commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     dnsruby (1.61.2)
@@ -26,18 +26,16 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    ffi (1.9.25-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    github-pages (191)
+    github-pages (192)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
-      jekyll (= 3.7.3)
+      jekyll (= 3.7.4)
       jekyll-avatar (= 0.6.0)
       jekyll-coffeescript (= 1.1.1)
       jekyll-commonmark-ghpages (= 0.1.5)
@@ -91,7 +89,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.3)
+    jekyll (3.7.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -225,9 +223,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.4-x64-mingw32)
-      mini_portile2 (~> 2.3.0)
-    octokit (4.11.0)
+    octokit (4.12.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
@@ -243,7 +239,7 @@ GEM
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
-    sass (3.5.7)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -262,7 +258,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   coderay
@@ -272,4 +267,4 @@ DEPENDENCIES
   pygments.rb (~> 1.1.2)
 
 BUNDLED WITH
-   1.16.4
+   1.16.1


### PR DESCRIPTION
updated version number in Dockerfile, updated gemfile.lock

* re-created docker image/container
* tested locally