### PR TITLE
Update documentation to reflect current installation and usage methods

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -60,8 +60,10 @@ docs:
           url: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/
   - title: docToolchain
     children:
-        - title: "User Manual"
-          url: https://doctoolchain.github.io/docToolchain
+        - title: "Current Documentation"
+          url: https://doctoolchain.org/docToolchain/v2.0.x/
+        - title: "GitHub Repository"
+          url: https://github.com/docToolchain/docToolchain
   - title: htmlSanityCheck
     children:
         - title: "Quick Guide"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -38,6 +38,10 @@ about:
 getstarted:
   - title: Get Started
     children:
+        - title: "Quickstart"
+          url: /getstarted/quickstart
+        - title: "docToolchain Wrapper (dtcw)"
+          url: /getstarted/dtcw-wrapper
         - title: "Full Example"
           url: /getstarted/tutorial2
         - title: "Tutorials"

--- a/docs/_pages/getstarted/dtcw-wrapper.adoc
+++ b/docs/_pages/getstarted/dtcw-wrapper.adoc
@@ -1,0 +1,123 @@
+= docToolchain Wrapper (dtcw)
+:page-layout: single
+:page-permalink: /getstarted/dtcw-wrapper
+:page-header: { overlay_image: /images/splash/get-started-599118-unsplash.jpg, caption: "[David Iskander](https://unsplash.com/photos/iWTamkU5kiI)" }
+:page-sidebar: { nav: getstarted}
+
+== The docToolchain Wrapper (dtcw)
+
+The docToolchain wrapper is a script that simplifies the installation and usage of docToolchain. It provides a consistent interface regardless of your operating system and eliminates the need to manually install and configure docToolchain.
+
+=== Benefits of the dtcw Wrapper
+
+* **Easy Installation**: Install docToolchain with a single command
+* **Environment Detection**: Automatically detects available environments (local, Docker, SDKMAN)
+* **Cross-Platform**: Works on Linux, macOS, and Windows
+* **Version Management**: Easily switch between different docToolchain versions
+* **Simplified Commands**: Run docToolchain commands without worrying about paths
+
+=== Installing the dtcw Wrapper
+
+To install the dtcw wrapper in your project, follow these steps:
+
+==== For Linux/macOS:
+
+[source,bash]
+----
+cd <your project>
+curl -Lo dtcw https://doctoolchain.org/dtcw
+chmod +x dtcw
+----
+
+If you don't have curl installed, you can also use wget:
+
+[source,bash]
+----
+cd <your project>
+wget doctoolchain.org/dtcw
+chmod +x dtcw
+----
+
+==== For Windows (PowerShell):
+
+[source,powershell]
+----
+cd <your project>
+Invoke-WebRequest doctoolchain.org/dtcw.ps1 -OutFile dtcw.ps1
+----
+
+=== Running docToolchain
+
+Once the wrapper is installed, you can run docToolchain commands directly. The wrapper will automatically install docToolchain if it's not already installed.
+
+==== Available Environments
+
+The dtcw wrapper supports multiple environments:
+
+* **local**: Installs docToolchain in the user's home directory ($HOME/.doctoolchain)
+* **docker**: Uses docToolchain from a Docker container (no local installation needed)
+* **sdk**: Uses SDKMAN! to manage docToolchain installation (if SDKMAN! is installed)
+
+You can specify which environment to use by adding it as the first argument:
+
+[source,bash]
+----
+# Use local installation
+./dtcw local generateHTML
+
+# Use Docker container
+./dtcw docker generateHTML
+
+# Use SDKMAN! installation
+./dtcw sdk generateHTML
+----
+
+If no environment is specified, the wrapper will automatically choose the best available environment.
+
+==== Common Commands
+
+Here are some common commands you can use with dtcw:
+
+[source,bash]
+----
+# Show available tasks
+./dtcw tasks --group=doctoolchain
+
+# Download the arc42 template
+./dtcw downloadTemplate
+
+# Generate HTML documentation
+./dtcw generateHTML
+
+# Generate PDF documentation
+./dtcw generatePDF
+
+# Publish to Confluence
+./dtcw publishToConfluence
+----
+
+=== Configuration
+
+When you first run a docToolchain command, the wrapper will create a `docToolchainConfig.groovy` file in your project directory. This file contains configuration options for docToolchain.
+
+You can modify this file to change how docToolchain processes your documentation. Common configurations include:
+
+* Setting input and output paths
+* Configuring which files to process
+* Setting up Confluence publishing options
+
+=== Updating docToolchain
+
+To update to a new version of docToolchain, edit the dtcw script and change the VERSION variable to the desired version number.
+
+For example, to update to version 2.1.0:
+
+1. Open the dtcw script in a text editor
+2. Look for a line like `DTC_VERSION=2.0.0` or `VERSION=2.0.0`
+3. Change it to `DTC_VERSION=2.1.0` or `VERSION=2.1.0`
+4. Save the file
+5. Run any dtcw command, and the new version will be installed automatically
+
+=== Further Information
+
+For more detailed information about docToolchain and the dtcw wrapper, visit the [official documentation](https://doctoolchain.github.io/docToolchain/v2.0.x/010_manual/20_install.html).

--- a/docs/_pages/getstarted/dtcw-wrapper.adoc
+++ b/docs/_pages/getstarted/dtcw-wrapper.adoc
@@ -34,7 +34,7 @@ If you don't have curl installed, you can also use wget:
 [source,bash]
 ----
 cd <your project>
-wget doctoolchain.org/dtcw
+wget https://doctoolchain.org/dtcw
 chmod +x dtcw
 ----
 

--- a/docs/_pages/getstarted/quickstart.adoc
+++ b/docs/_pages/getstarted/quickstart.adoc
@@ -90,7 +90,7 @@ For more detailed information, see the [official documentation](https://doctoolc
 
 If you are willing to install an editor or a plugin for your favorite IDE, you can install one of the following editors with the corresponding plugins:
 
-* https://asciidocfx.com/[AsciidocFX]
+* https://asciidocfx.com/[AsciiDocFX]
 * https://atom.io/users/asciidoctor[Atom]
 * https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode[Visual Studio Code]
 * https://plugins.jetbrains.com/plugin/7391-asciidoc[IntelliJ]

--- a/docs/_pages/getstarted/quickstart.adoc
+++ b/docs/_pages/getstarted/quickstart.adoc
@@ -14,13 +14,83 @@ The Quickstart basically consists of creating and rendering your first AsciiDoc 
 
 You just want to give AsciiDoc a try without installing anything?
 
-Go to https://asciidoclive.com/[AsciiDocLIVE] and use an online editor with preview.
+Go to https://asciidoclive.com[AsciiDocLIVE] and use an online editor with preview.
+
+=== The dtcw Wrapper Approach (recommended)
+
+The recommended way to use docToolchain is with the `dtcw` wrapper script, which simplifies installation and usage.
+
+[role='primary']
+--
+.> use dtcw Wrapper
+
+First, download the wrapper script into your project directory:
+
+For Linux/macOS:
+[source,bash]
+----
+cd <your project>
+curl -Lo dtcw https://doctoolchain.org/dtcw
+chmod +x dtcw
+----
+
+For Windows PowerShell:
+[source,powershell]
+----
+cd <your project>
+Invoke-WebRequest doctoolchain.org/dtcw.ps1 -OutFile dtcw.ps1
+----
+
+The wrapper script will handle installation of docToolchain when you run your first command.
+
+To download a template (like arc42):
+[source,bash]
+----
+./dtcw downloadTemplate
+----
+
+To see all available tasks:
+[source,bash]
+----
+./dtcw tasks --group=doctoolchain
+----
+
+To generate HTML from your AsciiDoc files:
+[source,bash]
+----
+./dtcw generateHTML
+----
+
+To generate PDF:
+[source,bash]
+----
+./dtcw generatePDF
+----
+
+If you want to create your first document, write it in AsciiDoc format:
+
+.test.adoc
+[source]
+----
+== Headline
+
+first paragraph
+
+second paragraph
+
+=== second level headline
+
+a link: https://docs-as-co.de[docs-as-co.de]
+----
+
+For more detailed information, see the [official documentation](https://doctoolchain.github.io/docToolchain/v2.0.x/010_manual/20_install.html).
+--
 
 === The Editor Approach
 
 If you are willing to install an editor or a plugin for your favorite IDE, you can install one of the following editors with the corresponding plugins:
 
-* https://asciidocfx.com/[AsciiDocFX]
+* https://asciidocfx.com/[AsciidocFX]
 * https://atom.io/users/asciidoctor[Atom]
 * https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode[Visual Studio Code]
 * https://plugins.jetbrains.com/plugin/7391-asciidoc[IntelliJ]
@@ -118,7 +188,7 @@ You wish for a very simple build file and the following line of text appears:
 .build.gradle
 [source,groovy]
 ----
-plugins { id "org.asciidoctor.convert" version "1.5.3" }
+plugins { id "org.asciidoctor.convert", version "1.5.3", }
 ----
 
 you write your very first AsciiDoc document and put it in `/src/docs/asciidoc/`

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -5,8 +5,8 @@ permalink: /
 header:
   overlay_image: /images/splash/hhgdac-splash.jpg
   overlay_filter: 0.5
-  #cta_label: "Overview"  # cta (== call-to-action) shows a button
-  #cta_url: "/overview"
+  cta_label: "Get Started" 
+  cta_url: "/getstarted/quickstart"
   caption: "[**Artem Sapegin**](https://unsplash.com/photos/b18TRXc8UPQ)"
 excerpt: "Code and documentation, created and maintained equally.
 developers love it, as it's effective and **takes the pain out of documentation**."
@@ -31,12 +31,22 @@ feature_row:
     excerpt: "Easily create and maintain various kinds of documentation, from architecture
     overviews, implementation guides to operations manuals."
 
+feature_row2:
+  - title: "docToolchain Wrapper (dtcw)"
+    # image_path: /images/wrapper-icon.svg
+    # alt: "wrapper-icon"
+    excerpt: "The easiest way to get started with docToolchain is to use the dtcw wrapper script, which handles installation and provides a consistent interface."
+    url: "/getstarted/dtcw-wrapper"
+    btn_label: "Learn More"
+    btn_class: "btn--primary"
 ---
 
 
 {% include feature_row id="intro" type="center" %}
 
 {% include feature_row %}
+
+{% include feature_row id="feature_row2" type="left" %}
 
 ## Why docs-as-code?
 


### PR DESCRIPTION
This PR addresses issue #1492 by updating the documentation on docs-as-co.de to reflect current installation and usage methods for docToolchain.

## Changes:

1. **Updated getstarted.adoc and quickstart.adoc**:
   - Added information about the recommended `dtcw` wrapper approach
   - Retained information about legacy approaches (Maven, Gradle, CLI)
   - Improved formatting and readability

2. **Added new dtcw-wrapper.adoc page**:
   - Created a dedicated page with detailed information about the dtcw wrapper
   - Included instructions for installation on different platforms
   - Explained common usage scenarios and configuration options

3. **Updated navigation**:
   - Added link to the new dtcw wrapper page
   - Reorganized the navigation structure to highlight the recommended approach
   - Updated links to current docToolchain documentation

4. **Updated home page**:
   - Added section highlighting the dtcw wrapper approach
   - Added call-to-action button leading to the quickstart guide
   - Improved overall messaging to guide users to the current recommended installation method

These changes help ensure that users are directed to the current recommended method for installing and using docToolchain (the dtcw wrapper) while maintaining information about other approaches for users who prefer them.

The updated documentation also links to the latest docToolchain documentation site for more detailed information.