### PR TITLE
Fix: relative paths so the site renders under the Pages sub-path

### DIFF
--- a/site/arc42.html
+++ b/site/arc42.html
@@ -10,19 +10,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html">what</a>
-        <a href="/how-it-works.html">how</a>
-        <a href="/why-doctoolchain.html">why docToolchain</a>
-        <a href="/arc42.html" aria-current="page">arc42</a>
-        <a href="/resources.html">resources</a>
+        <a href="what-is-docs-as-code.html">what</a>
+        <a href="how-it-works.html">how</a>
+        <a href="why-doctoolchain.html">why docToolchain</a>
+        <a href="arc42.html" aria-current="page">arc42</a>
+        <a href="resources.html">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -102,17 +102,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -131,6 +131,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -10,19 +10,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html">what</a>
-        <a href="/how-it-works.html" aria-current="page">how</a>
-        <a href="/why-doctoolchain.html">why docToolchain</a>
-        <a href="/arc42.html">arc42</a>
-        <a href="/resources.html">resources</a>
+        <a href="what-is-docs-as-code.html">what</a>
+        <a href="how-it-works.html" aria-current="page">how</a>
+        <a href="why-doctoolchain.html">why docToolchain</a>
+        <a href="arc42.html">arc42</a>
+        <a href="resources.html">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -57,7 +57,7 @@
           <span class="step-n">03</span>
           <div>
             <h3>Build on CI</h3>
-            <p>A pipeline renders the source on every commit: AsciiDoc becomes HTML and PDF, PlantUML becomes images, links get validated. Nothing is published by hand, so nothing drifts. This is the step where a toolchain earns its keep &mdash; and where <a href="/why-doctoolchain.html">docToolchain</a> does the heavy lifting.</p>
+            <p>A pipeline renders the source on every commit: AsciiDoc becomes HTML and PDF, PlantUML becomes images, links get validated. Nothing is published by hand, so nothing drifts. This is the step where a toolchain earns its keep &mdash; and where <a href="why-doctoolchain.html">docToolchain</a> does the heavy lifting.</p>
           </div>
         </div>
         <div class="step">
@@ -91,7 +91,7 @@
         <h2 style="margin:0.8rem 0 1rem;">Skip the plumbing.</h2>
         <p class="lead" style="margin-inline:auto;">docToolchain implements this whole workflow as one open-source toolchain. See what it gives you out of the box.</p>
         <div class="cta-row" style="justify-content:center;">
-          <a class="btn btn-primary" href="/why-doctoolchain.html">Why docToolchain <span class="arrow">&rarr;</span></a>
+          <a class="btn btn-primary" href="why-doctoolchain.html">Why docToolchain <span class="arrow">&rarr;</span></a>
           <a class="btn btn-ghost" href="https://doctoolchain.org" rel="noopener">Get started <span class="arrow">&#8599;</span></a>
         </div>
       </div>
@@ -102,17 +102,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -131,6 +131,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,19 +14,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html">what</a>
-        <a href="/how-it-works.html">how</a>
-        <a href="/why-doctoolchain.html">why docToolchain</a>
-        <a href="/arc42.html">arc42</a>
-        <a href="/resources.html">resources</a>
+        <a href="what-is-docs-as-code.html">what</a>
+        <a href="how-it-works.html">how</a>
+        <a href="why-doctoolchain.html">why docToolchain</a>
+        <a href="arc42.html">arc42</a>
+        <a href="resources.html">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -41,7 +41,7 @@
           <h1 class="reveal reveal-2">Treat your docs <span class="accent-word">as code</span>.</h1>
           <p class="lead reveal reveal-3">Plain-text source. Version control. Peer review. An automated build. The same discipline you trust for software, applied to the documentation around it.</p>
           <div class="cta-row reveal reveal-4">
-            <a class="btn btn-primary" href="/what-is-docs-as-code.html">Start here <span class="arrow">&rarr;</span></a>
+            <a class="btn btn-primary" href="what-is-docs-as-code.html">Start here <span class="arrow">&rarr;</span></a>
             <a class="btn btn-ghost" href="https://doctoolchain.org" rel="noopener">See the toolchain <span class="arrow">&#8599;</span></a>
           </div>
         </div>
@@ -93,7 +93,7 @@
           <span class="kicker">02 &mdash; the idea</span>
           <h2 style="margin:0.6rem 0 1rem;">It&rsquo;s a practice, not a product.</h2>
           <p class="lead">Docs-as-Code is a way of working: lightweight markup, a version-control system, reviews, and a build pipeline. The tools are interchangeable &mdash; the principles are what matter.</p>
-          <p style="margin-top:1.25rem;"><a class="btn btn-ghost" href="/what-is-docs-as-code.html">What is Docs-as-Code? <span class="arrow">&rarr;</span></a></p>
+          <p style="margin-top:1.25rem;"><a class="btn btn-ghost" href="what-is-docs-as-code.html">What is Docs-as-Code? <span class="arrow">&rarr;</span></a></p>
         </div>
         <ul class="diff-list" aria-label="Building blocks of Docs-as-Code">
           <li>Plain-text markup &mdash; AsciiDoc or Markdown</li>
@@ -118,7 +118,7 @@
           <div class="card"><span class="num">build</span><h3>Render on CI</h3><p>A pipeline transforms the source into HTML, PDF, or Confluence pages &mdash; automatically.</p></div>
           <div class="card"><span class="num">publish</span><h3>Ship it</h3><p>The output deploys like any other artifact. The latest docs are always one commit away.</p></div>
         </div>
-        <p style="margin-top:2rem;"><a class="btn btn-ghost" href="/how-it-works.html">See how it works <span class="arrow">&rarr;</span></a></p>
+        <p style="margin-top:2rem;"><a class="btn btn-ghost" href="how-it-works.html">See how it works <span class="arrow">&rarr;</span></a></p>
       </div>
     </section>
 
@@ -130,7 +130,7 @@
         <p class="lead" style="margin-inline:auto;">docToolchain wires the whole loop together &mdash; AsciiDoc, PlantUML, arc42 templates, and exports to HTML, PDF, and Confluence. Open source, batteries included.</p>
         <div class="cta-row" style="justify-content:center;">
           <a class="btn btn-primary" href="https://doctoolchain.org" rel="noopener">Get started with docToolchain <span class="arrow">&#8599;</span></a>
-          <a class="btn btn-ghost" href="/why-doctoolchain.html">Why docToolchain? <span class="arrow">&rarr;</span></a>
+          <a class="btn btn-ghost" href="why-doctoolchain.html">Why docToolchain? <span class="arrow">&rarr;</span></a>
         </div>
       </div>
     </section>
@@ -140,17 +140,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -169,6 +169,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>

--- a/site/resources.html
+++ b/site/resources.html
@@ -10,19 +10,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html">what</a>
-        <a href="/how-it-works.html">how</a>
-        <a href="/why-doctoolchain.html">why docToolchain</a>
-        <a href="/arc42.html">arc42</a>
-        <a href="/resources.html" aria-current="page">resources</a>
+        <a href="what-is-docs-as-code.html">what</a>
+        <a href="how-it-works.html">how</a>
+        <a href="why-doctoolchain.html">why docToolchain</a>
+        <a href="arc42.html">arc42</a>
+        <a href="resources.html" aria-current="page">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -80,7 +80,7 @@
         <p class="lead" style="margin-inline:auto;">If you want the assembled toolchain instead of building one, docToolchain is the fastest way in.</p>
         <div class="cta-row" style="justify-content:center;">
           <a class="btn btn-primary" href="https://doctoolchain.org" rel="noopener">Get started with docToolchain <span class="arrow">&#8599;</span></a>
-          <a class="btn btn-ghost" href="/">Back to start <span class="arrow">&rarr;</span></a>
+          <a class="btn btn-ghost" href="./">Back to start <span class="arrow">&rarr;</span></a>
         </div>
       </div>
     </section>
@@ -90,17 +90,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -119,6 +119,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>

--- a/site/what-is-docs-as-code.html
+++ b/site/what-is-docs-as-code.html
@@ -10,19 +10,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html" aria-current="page">what</a>
-        <a href="/how-it-works.html">how</a>
-        <a href="/why-doctoolchain.html">why docToolchain</a>
-        <a href="/arc42.html">arc42</a>
-        <a href="/resources.html">resources</a>
+        <a href="what-is-docs-as-code.html" aria-current="page">what</a>
+        <a href="how-it-works.html">how</a>
+        <a href="why-doctoolchain.html">why docToolchain</a>
+        <a href="arc42.html">arc42</a>
+        <a href="resources.html">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -76,7 +76,7 @@
         <h2 style="margin:0.8rem 0 1rem;">See the loop in motion.</h2>
         <p class="lead" style="margin-inline:auto;">Four steps take a documentation change from your editor to a published page.</p>
         <div class="cta-row" style="justify-content:center;">
-          <a class="btn btn-primary" href="/how-it-works.html">How it works <span class="arrow">&rarr;</span></a>
+          <a class="btn btn-primary" href="how-it-works.html">How it works <span class="arrow">&rarr;</span></a>
           <a class="btn btn-ghost" href="https://doctoolchain.org" rel="noopener">See the toolchain <span class="arrow">&#8599;</span></a>
         </div>
       </div>
@@ -87,17 +87,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -116,6 +116,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>

--- a/site/why-doctoolchain.html
+++ b/site/why-doctoolchain.html
@@ -10,19 +10,19 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <header class="site-header">
     <div class="wrap">
-      <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+      <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">menu</button>
       <nav class="nav" id="primary-nav" aria-label="Primary">
-        <a href="/what-is-docs-as-code.html">what</a>
-        <a href="/how-it-works.html">how</a>
-        <a href="/why-doctoolchain.html" aria-current="page">why docToolchain</a>
-        <a href="/arc42.html">arc42</a>
-        <a href="/resources.html">resources</a>
+        <a href="what-is-docs-as-code.html">what</a>
+        <a href="how-it-works.html">how</a>
+        <a href="why-doctoolchain.html" aria-current="page">why docToolchain</a>
+        <a href="arc42.html">arc42</a>
+        <a href="resources.html">resources</a>
         <a href="https://doctoolchain.org" rel="noopener">docToolchain&nbsp;&#8599;</a>
       </nav>
     </div>
@@ -73,7 +73,7 @@
         <p class="lead" style="margin-inline:auto;">Grab the wrapper, run a task, watch plain text become a published document. The quickstart takes minutes.</p>
         <div class="cta-row" style="justify-content:center;">
           <a class="btn btn-primary" href="https://doctoolchain.org" rel="noopener">Go to docToolchain <span class="arrow">&#8599;</span></a>
-          <a class="btn btn-ghost" href="/resources.html">Browse resources <span class="arrow">&rarr;</span></a>
+          <a class="btn btn-ghost" href="resources.html">Browse resources <span class="arrow">&rarr;</span></a>
         </div>
       </div>
     </section>
@@ -83,17 +83,17 @@
     <div class="wrap">
       <div class="cols">
         <div>
-          <a class="brand" href="/">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
+          <a class="brand" href="./">docs-as-co<span class="b-accent">.de</span><span class="caret">_</span></a>
           <p style="margin-top:0.75rem; color:var(--muted); max-width:30ch; font-size:0.95rem;">The hitchhiker&rsquo;s guide to documentation as code.</p>
         </div>
         <div>
           <h4>Learn</h4>
           <ul>
-            <li><a href="/what-is-docs-as-code.html">What is Docs-as-Code</a></li>
-            <li><a href="/how-it-works.html">How it works</a></li>
-            <li><a href="/why-doctoolchain.html">Why docToolchain</a></li>
-            <li><a href="/arc42.html">arc42</a></li>
-            <li><a href="/resources.html">Resources</a></li>
+            <li><a href="what-is-docs-as-code.html">What is Docs-as-Code</a></li>
+            <li><a href="how-it-works.html">How it works</a></li>
+            <li><a href="why-doctoolchain.html">Why docToolchain</a></li>
+            <li><a href="arc42.html">arc42</a></li>
+            <li><a href="resources.html">Resources</a></li>
           </ul>
         </div>
         <div>
@@ -112,6 +112,6 @@
     </div>
   </footer>
 
-  <script src="/assets/nav.js" defer></script>
+  <script src="assets/nav.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

After #75 merged, the site deployed to GitHub Pages and is reachable at
`https://doctoolchain.org/docs-as-co.de/` — but it renders **unstyled with broken
navigation**.

Cause: every internal link and asset used a **root-absolute** path
(`/assets/styles.css`, `/arc42.html`, …). Under the Pages sub-path those resolve
to the host root (`doctoolchain.org/assets/styles.css`) and **404**. The actual
files live under `/docs-as-co.de/...`.

## Fix

Switch all internal `href`/`src` to **relative** paths (`assets/styles.css`,
`arc42.html`, `./` for home). Relative paths resolve correctly **both** under a
sub-path **and** at the apex domain `docs-as-co.de`, so this is robust regardless
of how Pages serves the site.

Canonical / og:url meta tags keep their full `https://docs-as-co.de/...` URLs
(the intended canonical destination).

## Verification

Served the site under `/docs-as-co.de/` locally and loaded it in a browser:
all resources return 200 (CSS, `nav.js`, Google Fonts) and every nav link
resolves — page is fully styled. No console 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)