### PR TITLE
Prefix GoatCounter paths with docs-as-co.de

### DIFF
--- a/site/arc42.html
+++ b/site/arc42.html
@@ -124,12 +124,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -124,12 +124,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/imprint.html
+++ b/site/imprint.html
@@ -101,12 +101,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -162,12 +162,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/resources.html
+++ b/site/resources.html
@@ -112,12 +112,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/what-is-docs-as-code.html
+++ b/site/what-is-docs-as-code.html
@@ -109,12 +109,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/site/why-doctoolchain.html
+++ b/site/why-doctoolchain.html
@@ -105,12 +105,13 @@
       </div>
       <div class="footer-meta">
         <span>&copy; 2026 docs-as-co.de &mdash; Ralf D. M&uuml;ller &amp; Gernot Starke &middot; <a href="imprint.html">Imprint</a></span>
-        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.4.0</span>
+        <span class="ver"><span class="ci-dot" title="build passing"></span> v1.5.0</span>
       </div>
     </div>
   </footer>
 
   <script src="assets/nav.js" defer></script>
+  <script>window.goatcounter = { path: function (p) { return "docs-as-co.de" + p } };</script>
   <script data-goatcounter="https://doctoolchain.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #77 (that PR was merged before this commit landed).

The site reports into the shared `doctoolchain.goatcounter.com` account, where GoatCounter records only the path — so `docs-as-co.de` pages would collide with doctoolchain.org pages in the dashboard. This adds a GoatCounter `path` callback that prepends `docs-as-co.de` to every recorded path, so entries are self-identifying (e.g. `docs-as-co.de/arc42.html`).

Applied on all pages. Version bumped to `v1.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)