### PR TITLE
Remove internal disclaimer note from the public imprint

### DIFF
--- a/site/imprint.html
+++ b/site/imprint.html
@@ -67,8 +67,6 @@
 
         <h3>External links</h3>
         <p>This site links to external websites (for example doctoolchain.org, arc42.org, github.com). We are not responsible for the content or privacy practices of those sites.</p>
-
-        <blockquote>This text is provided in good faith and is not legal advice. Have it reviewed before relying on it.</blockquote>
       </div>
     </section>
   </main>


### PR DESCRIPTION
The imprint page ended with a blockquote — "This text is provided in good faith and is not legal advice. Have it reviewed before relying on it." — which was an internal note to us, not appropriate for a public Impressum. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)